### PR TITLE
jexkinsx-pipeline-nodejs to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: jexkinsx-pipeline-nodejs
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2


### PR DESCRIPTION
Promote jexkinsx-pipeline-nodejs to version 0.0.2